### PR TITLE
Fs 84 Tailwind configue with mui

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "sass-embedded": "^1.78.0",
     "storybook": "^8.5.1",
     "storybook-addon-tag-badges": "^1.3.2",
-    "tailwindcss": "^3.4.7",
+    "tailwindcss": "^3.4.17",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.1(prettier@3.4.2))
       tailwindcss:
-        specifier: ^3.4.7
+        specifier: ^3.4.17
         version: 3.4.17(ts-node@10.9.2(@swc/core@1.10.4)(@types/node@22.10.4)(typescript@5.7.2))
       ts-jest:
         specifier: ^29.2.5

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,7 +1,10 @@
+import GenericButton from '@src/components/Button';
+
 export default function HomePage() {
   return (
     <div className='size-full p-6'>
       <div className=' bg-dark-primary hover:bg-hover-primary hover:text-pressed-primary'>error</div>
+      <GenericButton className='bg-blue-500 dark:bg-red-500'>button of mui with tailwind</GenericButton>
     </div>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,7 @@ const tailwindConfig: Config = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   // safelist: [{ pattern: /^(bg-|border-|text-)/, variants: ['hover', 'active'] }, 'bg-red-200'],
   darkMode: ['class', '[data-theme="dark"]'], // <--- from tests I made on Storybook, this array doesn't work. Only the data-theme="dark" affects the result, and the class does nothing. At first I thought may there's an AND behavior, but no, just the data attributes affects it. The class is rendered useless in this array form.
+  important: '#root',
   theme: {
     screens,
     extend: {
@@ -37,6 +38,7 @@ const tailwindConfig: Config = {
   },
   corePlugins: {
     aspectRatio: false, // disable the aspectRatio core plugin to avoid conflicts with the native aspect-ratio utilities included in Tailwind CSS v3.0
+    preflight: false, // disable the preflight core plugin to avoid conflicts with the native preflight styles included in Tailwind CSS v3.0
   },
   variants: {
     animation: ({ after }) => after(['motion-safe', 'motion-reduce']),


### PR DESCRIPTION
Tailwind configue with mui

 disable the preflight core plugin to avoid conflicts with the native preflight styles included in Tailwind CSS v3.0

